### PR TITLE
Add working support for P12 Certificates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "acme_registration" "reg" {
 }
 
 resource "tls_cert_request" "req" {
+  count = local.private_key_provided ? 1 : 0
 
   key_algorithm   = "RSA"
   private_key_pem = var.private_key
@@ -33,42 +34,60 @@ resource "null_resource" "dns_check" {
 }
 
 locals {
+  private_key_provided = var.from_csr
   cloud_to_dns_provider_map = {
     "gcp" : "gcloud"
     "aws" : "route53"
     "azure" : "azure"
   }
+  acme_config = {
+    // GCP
+    GCE_PROJECT              = var.gcp_project_id
+    GCE_SERVICE_ACCOUNT_FILE = var.gcp_service_account_file
+    GCE_PROPAGATION_TIMEOUT  = var.dns_propagation_timeout
+    GCE_POLLING_INTERVAL     = var.dns_polling_interval
+
+    // AWS
+    AWS_PROFILE        = var.aws_profile
+    AWS_REGION         = var.aws_region
+    AWS_HOSTED_ZONE_ID = var.aws_zone_id
+
+    // AZURE
+    AZURE_SUBSCRIPTION_ID = var.azure_subscription_id
+    AZURE_TENANT_ID       = var.azure_tenant_id
+    AZURE_RESOURCE_GROUP  = var.azure_resource_group
+    AZURE_CLIENT_ID       = var.azure_client_id
+    AZURE_CLIENT_SECRET   = var.azure_client_secret
+    AZURE_ENVIRONMENT     = var.azure_environment
+  }
 }
 
-resource "acme_certificate" "certificate" {
+resource "acme_certificate" "certificate_from_csr" {
   depends_on = [null_resource.dns_check]
+  count      = local.private_key_provided ? 1 : 0
 
   account_key_pem         = acme_registration.reg.account_key_pem
-  certificate_request_pem = tls_cert_request.req.cert_request_pem
+  certificate_request_pem = tls_cert_request.req[0].cert_request_pem
 
   recursive_nameservers = ["8.8.8.8:53", "208.67.222.222:53", "208.67.220.220:53"]
 
   dns_challenge {
     provider = local.cloud_to_dns_provider_map[var.dns_provider]
-    config = {
-      // GCP
-      GCE_PROJECT              = var.gcp_project_id
-      GCE_SERVICE_ACCOUNT_FILE = var.gcp_service_account_file
-      GCE_PROPAGATION_TIMEOUT  = var.dns_propagation_timeout
-      GCE_POLLING_INTERVAL     = var.dns_polling_interval
+    config   = local.acme_config
+  }
+}
 
-      // AWS
-      AWS_PROFILE        = var.aws_profile
-      AWS_REGION         = var.aws_region
-      AWS_HOSTED_ZONE_ID = var.aws_zone_id
+resource "acme_certificate" "certificate_auto" {
+  depends_on = [null_resource.dns_check]
+  count      = local.private_key_provided ? 0 : 1
 
-      // AZURE
-      AZURE_SUBSCRIPTION_ID = var.azure_subscription_id
-      AZURE_TENANT_ID       = var.azure_tenant_id
-      AZURE_RESOURCE_GROUP  = var.azure_resource_group
-      AZURE_CLIENT_ID       = var.azure_client_id
-      AZURE_CLIENT_SECRET   = var.azure_client_secret
-      AZURE_ENVIRONMENT     = var.azure_environment
-    }
+  account_key_pem = acme_registration.reg.account_key_pem
+  common_name     = "*.${var.common_name}"
+
+  recursive_nameservers = ["8.8.8.8:53", "208.67.222.222:53", "208.67.220.220:53"]
+
+  dns_challenge {
+    provider = local.cloud_to_dns_provider_map[var.dns_provider]
+    config   = local.acme_config
   }
 }

--- a/output.tf
+++ b/output.tf
@@ -1,19 +1,19 @@
 output "issuer_pem" {
-  value = acme_certificate.certificate.issuer_pem
+  value = local.private_key_provided ? acme_certificate.certificate_from_csr[0].issuer_pem : acme_certificate.certificate_auto[0].issuer_pem
 }
 
 output "certificate_pem" {
-  value = acme_certificate.certificate.certificate_pem
+  value = local.private_key_provided ? acme_certificate.certificate_from_csr[0].certificate_pem : acme_certificate.certificate_auto[0].certificate_pem
 }
 
 output "private_key_pem" {
-  value = acme_certificate.certificate.private_key_pem
+  value = local.private_key_provided ? var.private_key : acme_certificate.certificate_auto[0].private_key_pem
 }
 
 output "certificate_p12" {
-  value = acme_certificate.certificate.certificate_p12
+  value = local.private_key_provided ? acme_certificate.certificate_from_csr[0].certificate_p12 : acme_certificate.certificate_auto[0].certificate_p12
 }
 
 output "certificate_p12_password" {
-  value = acme_certificate.certificate.certificate_p12_password
+  value = local.private_key_provided ? acme_certificate.certificate_from_csr[0].certificate_p12_password : acme_certificate.certificate_auto[0].certificate_p12_password
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,11 @@ variable "email_address" {
 variable "private_key" {
   type        = string
   description = "Private key pem"
+  default     = null
+}
+variable "from_csr" {
+  type    = bool
+  default = true
 }
 variable "dns_provider" {
   type = string


### PR DESCRIPTION
Basically, when using a custom CSR, p12 certificate is not created by acme_certificate resource...
We add a variable var.from_csr for opting in to usage of custom CSR.
By default var.from_csr is true, which means we have the very same behaviour as before